### PR TITLE
Fix XML RPC decode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "peoplefone/provisioning-rpc",
     "description": "Manage MAC addresses for the Auerswald, Gigaset, Panasonic, Snom, Yealink XML-RPC server to redirect them to your provisioning server.",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "keywords": ["provisioning","redirect server","xmlrpc","auerswald","gigaset","panasonic","snom","yealink"],
     "license": "MIT",
     "authors": [

--- a/src/ProvisioningRPCXML.php
+++ b/src/ProvisioningRPCXML.php
@@ -88,6 +88,12 @@ abstract class ProvisioningRPCXML implements ProvisioningRPCInterface
      */
     protected function decodeXml(string $data, array $options = [])
     {
-        return $this->encoder->decodeXml($data, $options);
+        $response = $this->encoder->decodeXml($data, $options);
+
+        if ($response instanceof Response && $response->faultCode()) {
+            throw new \RuntimeException("XML-RPC Fault {$response->faultCode()}: {$response->faultString()}");
+        }
+
+        return $this->encoder->decode($response->value());
     }
 }

--- a/src/ProvisioningRPCXML.php
+++ b/src/ProvisioningRPCXML.php
@@ -84,7 +84,6 @@ abstract class ProvisioningRPCXML implements ProvisioningRPCInterface
      * Decode XML
      * @param string $data
      * @param array $options
-     * @return false|Request|Response|Value
      */
     protected function decodeXml(string $data, array $options = [])
     {


### PR DESCRIPTION
This is to fix the XML RPC decode i.e. 

First decode $this->encoder->decodeXml returns an object. 
The second $this->encoder->decode converts the object to an array.